### PR TITLE
Fix duplicate viewport meta in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <title>Vite + React + TS</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- remove redundant viewport meta tag in index.html

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a3a8bbe98832aab1e6236f2bbeb08