### PR TITLE
Remove unused FaAws and FaNodeJs icons

### DIFF
--- a/src/components/Experience/Experiences.tsx
+++ b/src/components/Experience/Experiences.tsx
@@ -1,5 +1,5 @@
 import { Box, Container, Typography, Grid, Paper, List, ListItem, ListItemText, useTheme } from "@mui/material";
-import { FaJava, FaAws, FaNodeJs } from 'react-icons/fa';
+import { FaJava } from 'react-icons/fa';
 import { SiSpring, SiGitlab, SiJira, SiTypescript, SiAngular, SiReact, SiPostgresql, SiMongodb, SiPython, SiDocker, SiKubernetes } from 'react-icons/si';
 
 const experiences = [


### PR DESCRIPTION
## Summary
- prune unused imports from `Experiences`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a3a946e58832a8781e5bd4d8982e4